### PR TITLE
Call failure block back when fatal error occurred.

### DIFF
--- a/AFNetworking+RetryPolicy/AFHTTPSessionManager+RetryPolicy.m
+++ b/AFNetworking+RetryPolicy/AFHTTPSessionManager+RetryPolicy.m
@@ -140,6 +140,7 @@ SYNTHESIZE_ASC_PRIMITIVE(__retryPolicyLogMessagesEnabled, setRetryPolicyLogMessa
     void(^retryBlock)(NSURLSessionDataTask *, NSError *) = ^(NSURLSessionDataTask *task, NSError *error) {
         if ([self isErrorFatal:error]) {
             [self logMessage:@"Request failed with fatal error: %@ - Will not try again!", error.localizedDescription];
+            failure(task, error);
             return;
         }
         


### PR DESCRIPTION
There is an issue when fatal error occurred and the failure block was not called.
Therefore, would you please merge this pull request to fix this issue?
