### PR TITLE
Fix exponential backoff logic

### DIFF
--- a/AFNetworking+RetryPolicy/AFHTTPSessionManager+RetryPolicy.m
+++ b/AFNetworking+RetryPolicy/AFHTTPSessionManager+RetryPolicy.m
@@ -161,9 +161,8 @@ SYNTHESIZE_ASC_PRIMITIVE(__retryPolicyLogMessagesEnabled, setRetryPolicyLogMessa
             if (retryInterval > 0.0) {
                 dispatch_time_t delay;
                 if (progressive) {
-                    delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(pow(retryInterval, (maxRetry - retryRemaining) + 1) * NSEC_PER_SEC));
-                    [self logMessage:@"Delaying the next attempt by %.0f seconds …", pow(retryInterval, (maxRetry - retryRemaining) + 1)];
-                    
+                    delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(retryInterval * pow(2, maxRetry - retryRemaining) * NSEC_PER_SEC));
+                    [self logMessage:@"Delaying the next attempt by %.0f seconds …", retryInterval * pow(2, maxRetry - retryRemaining)];
                 } else {
                     delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(retryInterval * NSEC_PER_SEC));
                     [self logMessage:@"Delaying the next attempt by %.0f seconds …", retryInterval];


### PR DESCRIPTION
The current exponential backoff logic does not work well for any values other than 2.0.

The logic should be `retryInterval * 2^retryCount`.